### PR TITLE
Attachment and ban functionality fixes

### DIFF
--- a/app/Ban.php
+++ b/app/Ban.php
@@ -239,30 +239,21 @@ class Ban extends Model
     /**
      * Returns a fully qualified URL for a route on this ban.
      *
-     * @param  string  $route  Optional route addendum.
-     * @param  array  $params  Optional array of parameters to be added.
-     * @param  bool  $abs  Options indicator if the URL is to be absolute.
+     * @param  bool  $absolute  Options indicator if the URL is to be absolute.
      *
      * @return string
      */
-    public function getUrl($route = "", array $params = [], $abs = true)
+    public function getUrl($absolute = false)
     {
-        $defParams = ['ban' => $this->ban_id];
-
-        if (!$this->isGlobal()) {
-            $defParams += ['board' => $this->board_uri];
+        if ($this->isGlobal()) {
+            $route = 'panel.global.ban';
+            $parameters = ['ban' => $this->ban_id];
+        } else {
+            $route = 'panel.board.ban';
+            $parameters = ['board' => $this->board_uri, 'ban' => $this->ban_id];
         }
 
-        return route(
-            implode(array_filter([
-                "panel",
-                $this->isGlobal() ? "site" : "board",
-                "ban",
-                $route,
-            ]), '.'),
-            $defParams + $params,
-            true
-        );
+        return route($route, $parameters, $absolute);
     }
 
     /**

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -169,7 +169,7 @@ class PostRequest extends Request implements ApiContract
     public function forbiddenResponse()
     {
         if ($this->ban) {
-            $url = route('panel.banned');
+            $url = $this->ban->getUrl();
 
             if ($this->ajax() || $this->wantsJson()) {
                 return $this->apiResponse(['redirect' => $url]);

--- a/app/Http/Routes/Panel.php
+++ b/app/Http/Routes/Panel.php
@@ -49,15 +49,17 @@ Route::group(['middleware' => [ \App\Http\Middleware\BoardAmbivilance::class,],]
      * Bans and Appeals
      */
     Route::group(['prefix' => 'bans',], function () {
+        Route::get('/', ['as' => 'site.bans', 'uses' => 'BansController@getIndex']);
+
         Route::get('banned', ['as' => 'banned', 'uses' => 'BansController@getIndexForSelf']);
+
+        Route::get('board/{board}', ['as' => 'board.bans', 'uses' => 'BansController@getBoardIndex']);
 
         Route::get('board/{board}/{ban}', ['as' => 'board.ban', 'uses' => 'BansController@getBan']);
         Route::put('board/{board}/{ban}', ['as' => 'board.ban.appeal', 'uses' => 'BansController@putAppeal']);
-        Route::get('board/{board}', ['as' => 'board.ban', 'uses' => 'BansController@getBoardIndex']);
 
-        Route::get('global/{ban}', ['as' => 'site.ban', 'uses' => 'BansController@getBan']);
-        Route::put('global/{ban}', ['as' => 'site.ban.appeal', 'uses' => 'BansController@putAppeal']);
-        Route::get('/', ['as' => 'site.bans', 'uses' => 'BansController@getIndex']);
+        Route::get('global/{ban}', ['as' => 'global.ban', 'uses' => 'BansController@getBan']);
+        Route::put('global/{ban}', ['as' => 'global.ban.appeal', 'uses' => 'BansController@putAppeal']);
     });
 
     /**

--- a/app/Post.php
+++ b/app/Post.php
@@ -185,7 +185,8 @@ class Post extends Model implements FormattableContract
     public function attachments()
     {
         return $this->belongsToMany(FileStorage::class, 'file_attachments', 'post_id', 'file_id')
-            ->withPivot('attachment_id', 'filename', 'is_spoiler', 'is_deleted', 'position');
+            ->withPivot('attachment_id', 'filename', 'is_spoiler', 'is_deleted', 'position')
+            ->orderBy('position');
     }
 
     public function attachmentLinks()

--- a/resources/assets/js/app/widgets/postbox.widget.js
+++ b/resources/assets/js/app/widgets/postbox.widget.js
@@ -702,10 +702,14 @@
                         var json = response;
                     }
 
-                    if (typeof json.redirect !== "undefined")
+                    if (typeof json.redirect !== "undefined" && typeof json.post !== "undefined")
                     {
                         console.log("Post submitted. Redirecting.");
                         window.ib.storeYouPost(json.post.board_uri, json.post.board_id);
+                        window.location = json.redirect;
+                    }
+                    else if (typeof json.redirect !== "undefined")
+                    {
                         window.location = json.redirect;
                     }
                     else if (typeof json.errors !== "undefined")


### PR DESCRIPTION
Fixes #17 #37 

Attachments:
Dunno why he didn't just set orderBy in the first place, history shows that he used to `reverse` the order instead of ordering it at all.

Ban functionality:
Redirect was bugged with javascript, route names were a mess.
Apparently `window.location` is supposed to be absolute, versus `window.location.href`, but Firefox doesn't seem to care and no one has complained about redirects not happening when submitting threads. So it's probably alright.